### PR TITLE
Mint a fake VIP for ServiceEntries with no addresses

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,8 +5,12 @@ CoreDNS gRPC plugin to serve DNS records out of Istio ServiceEntries.
 The plugin runs as a separate container in the CoreDNS pod, serving DNS A
 records over gRPC to CoreDNS.
 
-Hosts in the service entries with the respective address specified in the
-service entry if the address is a non CIDR address.
+Hosts in service entries which also contain addresses will resolve to those
+addresses, as long as they're host addresses not CIDR ranges.
+
+Service entries without addresses will by default not resolve, unless the
+--default-address flag is given, in which case that address will be used
+for address-less service entries.
 
 Wildcard hosts in the service entries will also resolve appropriately.
 E.g., consider the following service entry:

--- a/plugin.go
+++ b/plugin.go
@@ -10,8 +10,8 @@ import (
 	"sync"
 	"time"
 
-	"github.com/miekg/dns"
 	dnsapi "github.com/istio-ecosystem/istio-coredns-plugin/api"
+	"github.com/miekg/dns"
 
 	networking "istio.io/api/networking/v1alpha3"
 	"istio.io/istio/pilot/pkg/config/kube/crd"

--- a/plugin.go
+++ b/plugin.go
@@ -89,7 +89,7 @@ func (h *IstioServiceEntries) readServiceEntries() {
 		if len(addresses) == 0 {
 			// If the ServiceEntry has no Addresses, just map to a
 			// fake value; effectively minting a VIP
-			addresses = []string{"42.0.0.69"}
+			addresses = []string{"127.255.127.127"}
 		}
 
 		vips := convertToVIPs(addresses)

--- a/plugin.go
+++ b/plugin.go
@@ -78,14 +78,21 @@ func (h *IstioServiceEntries) readServiceEntries() {
 			continue
 		}
 
-		if entry.Resolution == networking.ServiceEntry_NONE || len(entry.Addresses) == 0 {
+		if entry.Resolution == networking.ServiceEntry_NONE {
 			// NO DNS based service discovery for service entries
 			// that specify NONE as the resolution. NONE implies
 			// that Istio should use the IP provided by the caller
 			continue
 		}
 
-		vips := convertToVIPs(entry.Addresses)
+		addresses := entry.Addresses
+		if len(addresses) == 0 {
+			// If the ServiceEntry has no Addresses, just map to a
+			// fake value; effectively minting a VIP
+			addresses = []string{"42.0.0.69"}
+		}
+
+		vips := convertToVIPs(addresses)
 		if len(vips) == 0 {
 			continue
 		}

--- a/plugin.go
+++ b/plugin.go
@@ -170,7 +170,7 @@ func (h *IstioServiceEntries) Query(ctx context.Context, in *dnsapi.DnsPacket) (
 			}
 			h.mapMutex.RUnlock()
 			if vips != nil {
-				log.Printf("Found %s->%v\n", q.Name, ip)
+				log.Printf("Found %s->%v\n", q.Name, vips)
 				response.Answer = a(q.Name, vips)
 			}
 			//default:


### PR DESCRIPTION
Often, the ServiceEntries that we'd like to reflect in DNS don't have any addresses. E.g. this happens with SEs created by istio-ecosystem/mcc. Ideally, the SE would have an address, because that causes Istio to match requests sent to a `host: ` which is an IP. However on the DNS side the IP is irrelevant. All we need is for the e.g. `.global` name to resolve. We might as well use the real address(es) if they exist, for debugability, but otherwise can return anything. 

We use a 42 prefix address, but could use anything except loopback, as that traffic isn't redirected to envoy (https://github.com/istio/istio/blob/8a84d6ddcadef0505f0678e99d65eff88ff0b496/tools/deb/istio-iptables.sh#L313). (That said, technically loopback is the whole 127.0.0.0/8, but the proxy setup script uses host 127.0.0.1 host address...)