### PR TITLE
Default to send all DNS to core-dns

### DIFF
--- a/coredns.yaml
+++ b/coredns.yaml
@@ -41,7 +41,7 @@ data:
     .:53 {
         errors
         health
-        proxy global 127.0.0.1:8053 {
+        proxy . 127.0.0.1:8053 {
           protocol grpc insecure
         }
         prometheus :9153


### PR DESCRIPTION
This allows it to work out of the box in demos, fine-grained control can be done manually as required.